### PR TITLE
Prevent useless regular-expression character escape

### DIFF
--- a/web_server/config/models/all_dns.js
+++ b/web_server/config/models/all_dns.js
@@ -220,7 +220,7 @@ module.exports = {
         if (subdomain === undefined || subdomain === null || subdomain === 'all') {
             subdomain = '';
         }
-        let reAmazon = new RegExp('^.*' + subdomain + '\.amazonaws\.com');
+        let reAmazon = new RegExp('^.*' + subdomain + '\.amazonaws\\.com');
 
         let query = {
             'type': 'cname',

--- a/web_server/config/models/all_dns.js
+++ b/web_server/config/models/all_dns.js
@@ -220,7 +220,7 @@ module.exports = {
         if (subdomain === undefined || subdomain === null || subdomain === 'all') {
             subdomain = '';
         }
-        let reAmazon = new RegExp('^.*' + subdomain + '\.amazonaws\\.com');
+        let reAmazon = new RegExp('^.*' + subdomain + '\\.amazonaws\\.com');
 
         let query = {
             'type': 'cname',

--- a/web_server/config/models/all_dns.js
+++ b/web_server/config/models/all_dns.js
@@ -324,7 +324,7 @@ module.exports = {
          */
         let query = {};
 
-        let reDomain = new RegExp('.*\.' + domain_ending + '$');
+        let reDomain = new RegExp('.*\\.' + domain_ending + '$');
 
         query['fqdn'] = { "$regex": reDomain };
 

--- a/web_server/config/models/censys.js
+++ b/web_server/config/models/censys.js
@@ -124,7 +124,7 @@ module.exports = {
         }, { 'ip': 1, 'p443': 1 }).exec();
     },
     getCorpSSLCountPromise: function (internalDomain) {
-        let reCorp = new RegExp('^.*\.' + internalDomain);
+        let reCorp = new RegExp('^.*\\.' + internalDomain);
         return cSchema.censysModel.find({
             '$or': [{ 'p443.https.tls.certificate.parsed.subject.common_name': reCorp },
             { 'p443.https.tls.certificate.parsed.extensions.subject_alt_name.dns_names': reCorp }],

--- a/web_server/config/models/censys.js
+++ b/web_server/config/models/censys.js
@@ -105,7 +105,7 @@ module.exports = {
         return (promise);
     },
     getSSLByCorpNamePromise: function (internalDomain) {
-        let reCorp = new RegExp('^.*\.' + internalDomain);
+        let reCorp = new RegExp('^.*\\.' + internalDomain);
         return cSchema.censysModel.find({
             '$or': [{ 'p443.https.tls.certificate.parsed.subject.common_name': reCorp },
             { 'p443.https.tls.certificate.parsed.extensions.subject_alt_name.dns_names': reCorp }],

--- a/web_server/config/models/censys.js
+++ b/web_server/config/models/censys.js
@@ -84,7 +84,7 @@ module.exports = {
     },
     getSSLByZonePromise: function (zone, count) {
         let escZone = zone.replace('.', '\\.');
-        let reZone = new RegExp('^.*\.' + escZone + '$');
+        let reZone = new RegExp('^.*\\.' + escZone + '$');
         let promise;
         if (count) {
             promise = cSchema.censysModel.find({

--- a/web_server/config/models/censys.js
+++ b/web_server/config/models/censys.js
@@ -164,7 +164,7 @@ module.exports = {
     },
     getSSLAlgorithmByZonePromise: function (algorithm, zone, count) {
         let escZone = zone.replace('.', '\\.');
-        let reZone = new RegExp('^.*\.' + escZone + '$');
+        let reZone = new RegExp('^.*\\.' + escZone + '$');
         let promise;
         if (count === true) {
             promise = cSchema.censysModel.find({

--- a/web_server/config/models/cert_transparency.js
+++ b/web_server/config/models/cert_transparency.js
@@ -85,7 +85,7 @@ module.exports = {
     return promise;
   },
   getCertTransCorpPromise: function (corp_domain, excludeExpired, count) {
-    let reCorp = new RegExp('^.*\.' + corp_domain);
+    let reCorp = new RegExp('^.*\\.' + corp_domain);
     let promise;
     if (excludeExpired != null && excludeExpired === true) {
       if (count) {

--- a/web_server/config/models/cert_transparency.js
+++ b/web_server/config/models/cert_transparency.js
@@ -181,7 +181,7 @@ module.exports = {
     return promise;
   },
   getCorpCount: function (corp_domain) {
-    let reCorp = new RegExp('^.*\.' + corp_domain);
+    let reCorp = new RegExp('^.*\\.' + corp_domain);
     return certTransModel.find({
       '$or': [{ 'subject_common_names': reCorp },
       { 'subject_dns_names': reCorp }],

--- a/web_server/config/models/dead_dns.js
+++ b/web_server/config/models/dead_dns.js
@@ -109,7 +109,7 @@ module.exports = {
             || subdomain === 'dead') {
             subdomain = '';
         }
-        let reAmazon = new RegExp('^.*' + subdomain + '\.amazonaws\\.com');
+        let reAmazon = new RegExp('^.*' + subdomain + '\\.amazonaws\\.com');
 
         let query = {
             'type': 'cname',

--- a/web_server/config/models/dead_dns.js
+++ b/web_server/config/models/dead_dns.js
@@ -109,7 +109,7 @@ module.exports = {
             || subdomain === 'dead') {
             subdomain = '';
         }
-        let reAmazon = new RegExp('^.*' + subdomain + '\.amazonaws\.com');
+        let reAmazon = new RegExp('^.*' + subdomain + '\.amazonaws\\.com');
 
         let query = {
             'type': 'cname',

--- a/web_server/config/models/zgrab2_443_data.js
+++ b/web_server/config/models/zgrab2_443_data.js
@@ -211,7 +211,7 @@ module.exports = {
     },
     getSSLByZonePromise: function (zone, count, recursive) {
         let escZone = zone.replace('.', '\\.');
-        let reZone = new RegExp('^.*\.' + escZone + '$');
+        let reZone = new RegExp('^.*\\.' + escZone + '$');
         let promise;
         if (recursive === true) {
             if (count) {

--- a/web_server/config/models/zgrab2_443_data.js
+++ b/web_server/config/models/zgrab2_443_data.js
@@ -414,7 +414,7 @@ module.exports = {
     },
     getSSLAlgorithmByZonePromise: function (algorithm, zone, count, recursive, limit, page) {
         let escZone = zone.replace('.', '\\.');
-        let reZone = new RegExp('^.*\.' + escZone + '$');
+        let reZone = new RegExp('^.*\\.' + escZone + '$');
         let promise;
         if (recursive === true) {
             if (count === true) {

--- a/web_server/config/models/zgrab2_port.js
+++ b/web_server/config/models/zgrab2_port.js
@@ -170,7 +170,7 @@ module.exports = {
             { 'domain': 1, 'ip': 1, 'data.tls': 1 }).exec();
     },
     getSSLByCorpNamePromise: function (internalDomain, count) {
-        let reCorp = new RegExp('^.*\.' + internalDomain);
+        let reCorp = new RegExp('^.*\\.' + internalDomain);
         if (count) {
             return z2PortSchema.zgrab2PortModel.find({
                 '$or': [{ 'data.tls.result.handshake_log.server_certificates.certificate.parsed.subject.common_name': reCorp },

--- a/web_server/config/models/zgrab_443_data.js
+++ b/web_server/config/models/zgrab_443_data.js
@@ -348,7 +348,7 @@ module.exports = {
     },
     getSSLAlgorithmByZonePromise: function (algorithm, zone, count, recursive, limit, page) {
         let escZone = zone.replace('.', '\\.');
-        let reZone = new RegExp('^.*\.' + escZone + '$');
+        let reZone = new RegExp('^.*\\.' + escZone + '$');
         let promise;
         if (recursive === true) {
             if (count === true) {

--- a/web_server/config/models/zgrab_443_data.js
+++ b/web_server/config/models/zgrab_443_data.js
@@ -145,7 +145,7 @@ module.exports = {
     },
     getSSLByZonePromise: function (zone, count, recursive) {
         let escZone = zone.replace('.', '\\.');
-        let reZone = new RegExp('^.*\.' + escZone + '$');
+        let reZone = new RegExp('^.*\\.' + escZone + '$');
         let promise;
         if (recursive === true) {
             if (count) {

--- a/web_server/config/models/zgrab_port.js
+++ b/web_server/config/models/zgrab_port.js
@@ -170,7 +170,7 @@ module.exports = {
             { 'domain': 1, 'ip': 1, 'data.tls': 1 }).exec();
     },
     getSSLByCorpNamePromise: function (internalDomain) {
-        let reCorp = new RegExp('^.*\.' + internalDomain);
+        let reCorp = new RegExp('^.*\\.' + internalDomain);
         return zPortSchema.zgrabPortModel.find({
             '$or': [{ 'data.tls.server_certificates.certificate.parsed.subject.common_name': reCorp },
             { 'data.tls.server_certificates.certificate.parsed.extensions.subject_alt_name.dns_names': reCorp }],

--- a/web_server/routes/whois_db.js
+++ b/web_server/routes/whois_db.js
@@ -412,7 +412,7 @@ module.exports = function (envConfig) {
                 }
             } else if (req.query.hasOwnProperty('email')) {
                 let email = req.query.email;
-                let re = new RegExp('^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\.([a-zA-Z]{2,5})$');
+                let re = new RegExp('^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$');
                 if (email !== 'none' && !(re.test(email))) {
                     res.status(400).json({
                         'message': 'An invalid email has been provided',


### PR DESCRIPTION
## Description

This change improved some cases where useless regular-expression character escape is done in the code.
Using a regular expression with string literal (`new RegExp('[a-z]+')`) instead of regular expression slash syntax (`/[a-z]+/`) should be done with caution.
Usually, to escape `.` (dot) symbol within a regular expression, a developer would use backslash. But when it's done within a string literal (`new RegExp('\.')`) JavaScript will first process the string itself and only then call RegExp constructor.
It means `new RegExp('\.')` is equivalent to `/./`, which unintendedly allows to match any character instead of the intended dot only.
This may result in some security issues. For example, consider the hostname matching regular expression `new RegExp('www\.mysite\.com')`. In this case, an input of `http://www-mysite.com/` will pass the validation.

## Related Issue

https://github.com/adobe/Marinus/issues/8

## Motivation and Context

This code enhancement is done to avoid potential security issues.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

The developer intended the `\.` character to have a regular expression meaning - a `.` (dot) character - so the change replaces `\.` with `\\.` to avoid the issue and keep the intended logic.


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
